### PR TITLE
fix: register_backend created per backend, detect subclasses

### DIFF
--- a/databackend/tests/a_data_class.py
+++ b/databackend/tests/a_data_class.py
@@ -1,2 +1,6 @@
 class ADataClass:
     pass
+
+
+class ADataClass2:
+    pass

--- a/databackend/tests/test_databackend.py
+++ b/databackend/tests/test_databackend.py
@@ -3,7 +3,7 @@ import sys
 import importlib
 
 from databackend import AbstractBackend
-from databackend.tests.a_data_class import ADataClass
+from databackend.tests.a_data_class import ADataClass, ADataClass2
 
 CLASS_MOD = "databackend.tests.a_data_class"
 CLASS_NAME = "ADataClass"
@@ -71,3 +71,24 @@ def test_backends_spec_at_class_declaration():
         _backends = [(CLASS_MOD, CLASS_NAME)]
 
     assert issubclass(ADataClass, ABase)
+
+
+def test_backends_do_not_overlap():
+    class ABase1(AbstractBackend): ...
+
+    class ABase2(AbstractBackend): ...
+
+
+    ABase1.register_backend(CLASS_MOD, "ADataClass")
+    ABase2.register_backend(CLASS_MOD, "ADataClass2")
+
+    obj1 = ADataClass()
+    obj2 = ADataClass2()
+
+    assert isinstance(obj1, ABase1)
+    assert not isinstance(obj1, ABase2)
+
+
+    assert not isinstance(obj2, ABase1)
+    assert isinstance(obj2, ABase2)
+


### PR DESCRIPTION
This PR fixes two things:

* Ensure an empty `_backends` list is created per meta subclass. This was erroneously being created once for `AbstractBackend`, which meant that subclasses of `AbstractBackend` could share the same backends list.
* Correctly detect subclasses. Previously, only exact classes were detected, due to a bug in the order of arguments to an `issubclass` call.