### PR TITLE
feat: LazyImport class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 
+
 # databackend
 
-The `databackend` package allows you to register a subclass, without
-needing to import the subclass itself. This is useful for implementing
-actions over optional dependencies.
+The `databackend` package allows you to work with optional Python
+dependencies. It supports two use cases:
 
-## Example
+- `isinstance` checks on optional classes. The `AbstractBackend` class
+  represents a class without ever needing to do an import. This is
+  useful for generic function dispatch (e.g. with
+  `functools.singledispatch`).
+- Lazy module imports. The `LazyImport` class represents a module, but
+  doesn’t import it until you access an attribute from it.
+
+## AbstractBackend Example
 
 For this example, we’ll implement a function, `fill_na()`, that fills in
 missing values in a DataFrame. It works with DataFrame objects from two
@@ -128,9 +135,9 @@ def _(data: AbstractPandasFrame, x):
 
 Note two important decorators:
 
--   `@singledispatch` defines a default function. This gets called if no
-    specific implementations are found.
--   `@fill_na2.register` defines specific versions of the function.
+- `@singledispatch` defines a default function. This gets called if no
+  specific implementations are found.
+- `@fill_na2.register` defines specific versions of the function.
 
 Here’s an example of it in action.
 
@@ -179,11 +186,61 @@ the tuple `("<mod_name>", "<class_name>")`.
 
 When `issubclass(SomeClass, AbstractBackend)` runs, then…
 
--   The standard ABC caching mechanism is checked, and potentially
-    returns the answer immediately.
--   Otherwise, a subclass hook cycles through registered backends.
--   The hook runs the subclass check for any backends that are imported
-    (e.g. are in `sys.modules`).
+- The standard ABC caching mechanism is checked, and potentially returns
+  the answer immediately.
+- Otherwise, a subclass hook cycles through registered backends.
+- The hook runs the subclass check for any backends that are imported
+  (e.g. are in `sys.modules`).
 
 Technically, `AbstractBackend` inherits all the useful metaclass things
 from `abc.ABCMeta`, so these can be used also.
+
+## LazyImport Example
+
+``` python
+from databackend import LazyImport
+
+pl = LazyImport("polars")            # no import yet
+
+def my_func():
+    return pl.DataFrame({"x": [1]})  # imports polars on first use
+```
+
+Generally, you would put the lazy import into a submodule. As a simple
+example, copy the code below into a file called `_dependencies.py`.
+
+### As a dependencies submodule
+
+\*\*\_dependencies.py\*\*:
+
+``` python
+from databackend import LazyImport
+
+pl = LazyImport("polars")
+```
+
+Then, copy the code below into a file called `main_module.py` in the
+same directory.
+
+**main_module.py**:
+
+``` python
+from _dependencies import pl
+
+def my_func():
+    return pl.DataFrame({"x": [1]})  # imports polars on first use
+```
+
+### Debugging
+
+Use the debug flag to make LazyImport error instead of performing the
+import. This is helpful for discovering where you’ve accidentally
+induced an import in your code.
+
+``` python
+from databackend import LazyImport
+
+pathlib = LazyImport("pathlib", debug=True)
+
+pathlib.__name__    # raises ImportError
+```

--- a/README.qmd
+++ b/README.qmd
@@ -14,11 +14,14 @@ pd.set_option("display.notebook_repr_html", False)
 
 ```
 
-The `databackend` package allows you to register a subclass, without needing to import the subclass itself.
-This is useful for implementing actions over optional dependencies.
+The `databackend` package allows you to work with optional Python dependencies.
+It supports two use cases:
+
+* `isinstance` checks on optional classes. The `AbstractBackend` class represents a class without ever needing to do an import. This is useful for generic function dispatch (e.g. with `functools.singledispatch`).
+* Lazy module imports. The `LazyImport` class represents a module, but doesn't import it until you access an attribute from it.
 
 
-## Example
+## AbstractBackend Example
 
 For this example, we'll implement a function, `fill_na()`, that fills in missing values
 in a DataFrame.
@@ -175,3 +178,50 @@ When `issubclass(SomeClass, AbstractBackend)` runs, then...
 * The hook runs the subclass check for any backends that are imported (e.g. are in `sys.modules`).
 
 Technically, `AbstractBackend` inherits all the useful metaclass things from `abc.ABCMeta`, so these can be used also.
+
+## LazyImport Example
+
+```{python}
+from databackend import LazyImport
+
+pl = LazyImport("polars")            # no import yet
+
+def my_func():
+    return pl.DataFrame({"x": [1]})  # imports polars on first use
+```
+
+Generally, you would put the lazy import into a submodule. As a simple example,
+copy the code below into a file called `_dependencies.py`.
+
+### As a dependencies submodule
+
+**_dependencies.py**:
+
+```python
+from databackend import LazyImport
+
+pl = LazyImport("polars")
+```
+
+Then, copy the code below into a file called `main_module.py` in the same directory.
+
+**main_module.py**:
+
+```python
+from _dependencies import pl
+
+def my_func():
+    return pl.DataFrame({"x": [1]})  # imports polars on first use
+```
+
+### Debugging
+
+Use the debug flag to make LazyImport error instead of performing the import. This is helpful for discovering where you've accidentally induced an import in your code.
+
+```python
+from databackend import LazyImport
+
+pathlib = LazyImport("pathlib", debug=True)
+
+pathlib.__name__    # raises ImportError
+```

--- a/databackend/__init__.py
+++ b/databackend/__init__.py
@@ -62,3 +62,61 @@ class AbstractBackend(metaclass=_AbstractBackendMeta):
                     return True
 
         return NotImplemented
+
+
+# LazyImport --------
+# lazy import class ----
+
+import importlib  # noqa
+from types import ModuleType  # noqa
+
+
+class LazyImport(ModuleType):
+    """Lazily represents an imported module.
+
+    Parameters
+    ----------
+    name :
+        The name of the module to import.
+    fast :
+        If True, the module's attributes will be set on this instance after import, so
+        they can be imported without calling this class's `__getattr__` method.
+
+        This assumes that the module does not update its attributes after import.
+    debug :
+        If True, raise an error instead of importing the module. This allows you to see
+        what exactly triggers imports.
+
+    Examples
+    --------
+
+    >>> pl = LazyImport("polars")            # no import yet
+    >>> def my_func():
+    ...     return pl.DataFrame({"x": [1]})  # imports polars on first use
+    """
+
+    def __init__(self, name: str, fast: bool = False, debug: bool = False):
+        self.__mod: ModuleType | None = None
+
+        self.__name = name
+        self.__fast = fast
+        self.__debug = debug
+
+    def __getattr__(self, name: str):
+        if self.__mod is None:
+            self.__mod = self.__import()
+
+        return getattr(self.__mod, name)
+
+    def __import(self) -> ModuleType:
+        if self.__debug:
+            raise ImportError(
+                f"Lazy import of `{self.__name}` is disabled for debugging purposes."
+            )
+
+        mod = importlib.import_module(self.__name)
+
+        if self.__fast:
+            self.__dict__.update(mod.__dict__)
+
+        return mod

--- a/databackend/tests/test_databackend.py
+++ b/databackend/tests/test_databackend.py
@@ -34,6 +34,7 @@ def test_check_unimported_mod(Base):
     mod = importlib.import_module(mod_name)
 
     assert issubclass(mod.UnimportedClass, ABase)
+    del sys.modules[mod_name]
 
 
 def test_issubclass(Base):

--- a/databackend/tests/test_lazy_import.py
+++ b/databackend/tests/test_lazy_import.py
@@ -1,0 +1,13 @@
+from databackend import LazyImport
+import sys
+
+
+def test_lazy_import():
+    mod_name = "databackend.tests.an_unimported_module"
+    data_mod = LazyImport(mod_name)
+
+    assert mod_name not in sys.modules
+    data_mod.UnimportedClass
+
+    assert mod_name in sys.modules
+    del sys.modules[mod_name]


### PR DESCRIPTION
This PR adds a LazyImport class, heavily inspired by Polars, to represent the lazy import of modules. It doesn't perform the actual import until the last moment necessary (e.g. anything that does any kind of attribute access, including method calls).